### PR TITLE
Search for reports containing the query in the custom data section

### DIFF
--- a/classes/Http/Controllers/SearchController.php
+++ b/classes/Http/Controllers/SearchController.php
@@ -17,6 +17,7 @@ class SearchController extends BaseController
                 ->from('reports', 'R')
                 ->leftJoin('R', 'applications', 'A', 'A.id = R.application_id')
                 ->where($qb->expr()->like('R.stack_trace', ':query'))
+                ->orWhere($qb->expr()->like('R.custom_data', ':query'))
                 ->orWhere($qb->expr()->like('A.title', ':query'))
                 ->orderBy('R.created_at', 'DESC');
             /** @var $group \Doctrine\DBAL\Query\QueryBuilder */


### PR DESCRIPTION
When a user sends us an email we submit an acra report as well and link report and email with an UUID. This UUID will be concatenated to the email and appears inside the custom_data-section of the report. With this new feature we can search for reports containing a special UUID.