### PR TITLE
Accept new reports via HTTP PUT - closes #8

### DIFF
--- a/classes/Http/Providers/RoutesServiceProvider.php
+++ b/classes/Http/Providers/RoutesServiceProvider.php
@@ -17,6 +17,8 @@ class RoutesServiceProvider implements ServiceProviderInterface
 
         $app->post('/api', 'ApiController:save');
 
+        $app->put('/api/{report_id}', 'ApiController:save');
+
         $app->get('/applications', 'ApplicationsController:index')
             ->bind('applications');
 

--- a/www/index.php
+++ b/www/index.php
@@ -50,7 +50,7 @@ $app->register(new SecurityServiceProvider(), array(
     'security.firewalls' => array(
         'login' => array(
             'anonymous' => true,
-            'pattern' => '^/(api|login)$',
+            'pattern' => '^/(api(/[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})?|login)$',
         ),
         'admin' => array(
             'form' => array(


### PR DESCRIPTION
Added the route /api/{report_id} as valid route for put-requests. Therefor the pattern for non-authorized requests had to be extended. Now the path /api/<UUID> is allow to pass the security firewall.