### PR TITLE
Added script to generate a release bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ storage/twig/*
 www/*
 .env
 
+release-*.zip
+
 !www/.htaccess
 !www/index.php
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,9 @@
       "npm i",
       "bower i",
       "gulp"
-    ]
+    ],
+    "build": "composer update && npm i && bower i && gulp",
+    "make-release-bundle": "./makeReleaseBundle.sh"
   },
   "type": "project"
 }

--- a/makeReleaseBundle.sh
+++ b/makeReleaseBundle.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+    then
+        echo "$0 versionName"
+        exit -1
+fi
+
+version=$1
+
+composer run-script build
+
+zip -r release-${version}.zip . -x .\* -x bower_components/\* -x node_modules/\* -x .env\* -x composer.\* \
+                                -x bower.json -x .gitignore -x gulpfile.js -x makeReleaseBundle.sh -x package.json \
+                                -x release-\*.zip


### PR DESCRIPTION
Updates all dependencies and generates a zip-file with all files needed to run this application in production mode so you don't need to install dev-dependencies like composer, node.js, gulp or bower on the production server.

You can run the script either via "composer run-script make-release-bundle -- <version-name>" or "./makeReleaseBundle.sh <version-name>". This will generate a zip file with the name "release-<version-name>.zip".

Maybe this could be useful for someone else, too ;-)