### PR TITLE
Feature: hide reports

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -114,7 +114,7 @@
         $actions.each(function (i, el) {
             var $el = $(el),
                 action = $el.data('action');
-            $el.click(function () {
+            $el.click(function (e) {
                 if (action == 'refresh') {
                     $datatable.ajax.reload(null, false);
                 } else if (action == 'deselect') {
@@ -125,7 +125,23 @@
                     $.each($table.find('tbody tr td > input[name="row_id"]'), function (i, ele) {
                         $(ele).prop('checked', true);
                     });
-                } else if (action.indexOf('delete:') === 0) {
+                } else if (action == 'show-hidden-reports') {
+                    e.preventDefault();
+                    var actionValue = $el.data('value');
+                    var url;
+                    if (actionValue == 'hide') {
+                        url = $table.data('url') + '/false';
+                        //$datatableUrl = $datatable.ajax.url($table.data('url') + '/false');
+                        $el.data('value', 'show');
+                        $el.html('Show hidden reports');
+                    } else {
+                        url = $table.data('url') + '/true';
+                        //$datatableUrl = $datatable.ajax.url($table.data('url') + '/true');
+                        $el.data('value', 'hide');
+                        $el.html('Hide hidden reports');
+                    }
+                    $datatable.ajax.url(url).load();
+                } else if (action.indexOf('delete:') === 0 || action.indexOf('hide:') === 0 || action.indexOf('show:') === 0) {
                     var selected = [];
                     $.each($table.find('tbody tr td > input[name="row_id"]:checked'), function (i, ele) {
                         selected.push($(ele).val());
@@ -167,6 +183,22 @@
                                 $.growl('Please select at least one crash report to delete.', { type: 'warning' });
                             }
                             break;
+                        case 'hide:report':
+                        case 'show:report':
+                        {
+                            if (selected.length >= 1) {
+                                $.post($el.data('url'), {
+                                    row_ids: selected
+                                }).error(function () {
+                                    $.growl('Unable to ' + ((action == 'hide:report') ? 'hide' : 'show') + ' selected crash reports.', { type: 'danger' });
+                                }).success(function () {
+                                    $.growl('Selected crash reports have been made ' + ((action == 'hide:report') ? 'hidden' : 'visible again') + '.', { type: 'success' });
+                                    $datatable.ajax.reload(null, false);
+                                });
+                            } else {
+                                $.growl('Please select at least one crash report to hide/show.', { type: 'warning' });
+                            }
+                        }
                         default:
                             break;
                     }

--- a/assets/less/app.less
+++ b/assets/less/app.less
@@ -71,6 +71,10 @@ pre {
   height: 16px;
 }
 
+.show-hidden-reports-link {
+  margin-right: 20px;
+}
+
 // Source https://github.com/bassjobsen/typeahead.js-bootstrap-css/blob/master/typeaheadjs.less
 
 span.twitter-typeahead {

--- a/assets/locales/en.php
+++ b/assets/locales/en.php
@@ -19,6 +19,8 @@ return array(
     'buttons'=> array(
         'add' => 'Add',
         'delete' => 'Delete',
+        'hide' => 'Hide',
+        'show' => 'Show',
         'deselect_all' => 'Deselect All',
         'login' => 'Login',
         'refresh' => 'Refresh',
@@ -114,6 +116,7 @@ return array(
         'no_crashes' => 'No crashes reported',
         'report_count' => 'Report Count',
         'reported_on' => 'Reported On',
+        'hidden' => 'Hidden',
         'token' => 'Token'
     ),
     'text'=> array(

--- a/assets/twig/partials/actions.twig
+++ b/assets/twig/partials/actions.twig
@@ -1,4 +1,7 @@
 <div class="btn-toolbar pull-right">
+    <div class="btn-group btn-group-xs show-hidden-reports-link">
+        <a href="" id="show-hidden-reports" data-action="show-hidden-reports" data-value="show">Show hidden reports</a>
+    </div>
     <div class="btn-group btn-group-xs">
         <button class="btn btn-default" data-action="refresh">
             <i class="fa fa-fw fa-refresh"></i>
@@ -13,6 +16,18 @@
         <button class="btn btn-info" data-action="deselect">
             <i class="fa fa-fw fa-square-o"></i>
             <span class="hidden-xs">{{ 'buttons.deselect_all'|trans }}</span>
+        </button>
+    </div>
+    <div class="btn-group btn-group-xs">
+        <button class="btn btn-warning" data-action="hide:{{ ns }}" data-url="{{ url(routes.hide) }}">
+            <i class="fa fa-eye-slash"></i>
+            <span class="hidden-xs">{{ 'buttons.hide'|trans }}</span>
+        </button>
+    </div>
+    <div class="btn-group btn-group-xs">
+        <button class="btn btn-warning" data-action="show:{{ ns }}" data-url="{{ url(routes.show) }}">
+            <i class="fa fa-eye"></i>
+            <span class="hidden-xs">{{ 'buttons.show'|trans }}</span>
         </button>
     </div>
     <div class="btn-group btn-group-xs">

--- a/assets/twig/reports.twig
+++ b/assets/twig/reports.twig
@@ -8,7 +8,7 @@
             <h4 class="panel-title"><i class="fa fa-fw fa-navicon"></i> {{ title|trans }}</h4>
         </div>
         <div class="panel-body">
-            <table class="table table-bordered table-hover table-striped" data-role="datatable" data-url="{{ url(routes.data) }}" data-view="{{ url(routes.view, {id: '%d'})|url_decode }}">
+            <table class="table table-bordered table-hover table-striped" data-role="datatable" data-url="{{ url(routes.data) }}" data-show-hidden-reports="true" data-view="{{ url(routes.view, {id: '%d'})|url_decode }}">
                 <thead>
                 <tr>
                     <th data-key="id">#</th>
@@ -17,6 +17,7 @@
                     <th data-key="phone_model">{{ 'table.device'|trans }}</th>
                     <th data-key="crash_count">{{ 'table.crash_count'|trans }}</th>
                     <th data-key="created_at">{{ 'table.reported_on'|trans }}</th>
+                    <th data-key="hidden">{{ 'table.hidden'|trans }}</th>
                 </tr>
                 </thead>
                 <tfoot>
@@ -27,6 +28,7 @@
                     <th>{{ 'table.device'|trans }}</th>
                     <th>{{ 'table.crash_count'|trans }}</th>
                     <th>{{ 'table.reported_on'|trans }}</th>
+                    <th>Hidden</th>
                 </tr>
                 </tfoot>
             </table>

--- a/classes/Http/Controllers/DashboardController.php
+++ b/classes/Http/Controllers/DashboardController.php
@@ -11,6 +11,7 @@ class DashboardController extends BaseController
         $qb->select('A.title', 'A.package_name', 'R.checksum', 'R.created_at AS last_crashed_on')
             ->from('reports', 'R')
             ->leftJoin('R', 'applications', 'A', 'A.id = R.application_id')
+            ->where($qb->expr()->eq('hidden', '0'))
             ->orderBy('last_crashed_on', 'DESC');
         /** @var $group \Doctrine\DBAL\Query\QueryBuilder */
         $group = $this->container['db']->createQueryBuilder();;
@@ -23,6 +24,7 @@ class DashboardController extends BaseController
         $qb = $this->container['db']->createQueryBuilder();
         $qb->select('exception', 'checksum', 'created_at AS last_reported_on')
             ->from('reports')
+            ->where($qb->expr()->eq('hidden', '0'))
             ->orderBy('last_reported_on', 'DESC');
         /** @var $group \Doctrine\DBAL\Query\QueryBuilder */
         $group = $this->container['db']->createQueryBuilder();;

--- a/classes/Http/Controllers/HideController.php
+++ b/classes/Http/Controllers/HideController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Acraviz\Http\Controllers;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\Response;
+
+class HideController extends BaseController
+{
+
+    public function reports()
+    {
+        return new Response('', $this->hide('reports'));
+    }
+
+    public function showReports()
+    {
+        return new Response('', $this->show('reports'));
+    }
+
+    private function hide($table)
+    {
+        return $this->hideOrShow($table, true);
+    }
+
+    private function show($table)
+    {
+        return $this->hideOrShow($table, false);
+    }
+
+    private function hideOrShow($table, $hide) {
+        /** @var $request \Symfony\Component\HttpFoundation\Request */
+        $request = $this->container['request'];
+        /** @var $qb \Doctrine\DBAL\Query\QueryBuilder */
+        $qb = $this->container['db']->createQueryBuilder();
+        $result = $qb->update($table)
+            ->set('hidden', ($hide) ? '1' : '0')
+            ->where($qb->expr()->in('id', '?'))
+            ->setParameter(0, $request->get('row_ids'), Connection::PARAM_INT_ARRAY)
+            ->execute();
+        return $result >= 1 ? 200 : 500;
+    }
+}

--- a/classes/Http/Controllers/ReportsController.php
+++ b/classes/Http/Controllers/ReportsController.php
@@ -12,6 +12,8 @@ class ReportsController extends BaseController
             'routes' => array(
                 'data' => 'datatables_reports',
                 'delete' => 'delete_reports',
+                'hide' => 'hide_reports',
+                'show' => 'show_reports',
                 'view' => 'reports_view'
             ),
             'title' => 'titles.reports'

--- a/classes/Http/Providers/ControllersServiceProvider.php
+++ b/classes/Http/Providers/ControllersServiceProvider.php
@@ -7,6 +7,7 @@ use Acraviz\Http\Controllers\ApiController;
 use Acraviz\Http\Controllers\DashboardController;
 use Acraviz\Http\Controllers\DatatablesController;
 use Acraviz\Http\Controllers\DeleteController;
+use Acraviz\Http\Controllers\HideController;
 use Acraviz\Http\Controllers\LoginController;
 use Acraviz\Http\Controllers\ReportsController;
 use Acraviz\Http\Controllers\SearchController;
@@ -40,6 +41,10 @@ class ControllersServiceProvider implements ServiceProviderInterface
         $app['DeleteController'] = $app->share(function () use ($app)
         {
             return new DeleteController($app);
+        });
+        $app['HideController'] = $app->share(function () use ($app)
+        {
+            return new HideController($app);
         });
         $app['LoginController'] = $app->share(function () use ($app)
         {

--- a/classes/Http/Providers/RoutesServiceProvider.php
+++ b/classes/Http/Providers/RoutesServiceProvider.php
@@ -52,6 +52,8 @@ class RoutesServiceProvider implements ServiceProviderInterface
         $datatables->post('/reports', 'DatatablesController:reports')
             ->bind('datatables_reports');
 
+        $datatables->post('/reports/{showHiddenReports}', 'DatatablesController:reports');
+
         $app->mount('/datatables', $datatables);
 
         /** var $delete \Silex\ControllerCollection */
@@ -64,6 +66,22 @@ class RoutesServiceProvider implements ServiceProviderInterface
             ->bind('delete_reports');
 
         $app->mount('/delete', $delete);
+
+        /** var $hide \Silex\ControllerCollection */
+        $hide = $app['controllers_factory'];
+
+        $hide->post('/reports', 'HideController:reports')
+            ->bind('hide_reports');
+
+        $app->mount('/hide', $hide);
+
+        /** var $hide \Silex\ControllerCollection */
+        $show = $app['controllers_factory'];
+
+        $show->post('/reports', 'HideController:showReports')
+            ->bind('show_reports');
+
+        $app->mount('/show', $show);
     }
 
     /**

--- a/classes/Support/Datatables.php
+++ b/classes/Support/Datatables.php
@@ -101,7 +101,11 @@ class Datatables
         /**
          * Fetch Results
          */
-        $output['data'] = $this->query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        $data = $this->query->execute()->fetchAll(\PDO::FETCH_ASSOC);
+        foreach ($data as $index => $item) {
+            $data[$index]['hidden'] = ($item['hidden'] == '0') ? 'no' : 'yes';
+        }
+        $output['data'] = $data;
         /**
          * Add Filter
          */

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "twig/twig": "^1.18",
     "vlucas/phpdotenv": "^2.0",
     "symfony/config": "^2.7",
-    "ircmaxell/random-lib": "^1.1"
+    "ircmaxell/random-lib": "^1.1",
+    "robmorgan/phinx": "^0.6.5"
   },
   "scripts" : {
     "post-create-project-cmd": [

--- a/db/migrations/20170120100834_hide_reports.php
+++ b/db/migrations/20170120100834_hide_reports.php
@@ -1,0 +1,34 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class HideReports extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     *
+     * The following commands can be used in this method and Phinx will
+     * automatically reverse them when rolling back:
+     *
+     *    createTable
+     *    renameTable
+     *    addColumn
+     *    renameColumn
+     *    addIndex
+     *    addForeignKey
+     *
+     * Remember to call "create()" or "update()" and NOT "save()" when working
+     * with the Table class.
+     */
+    public function change()
+    {
+        $table = $this->table('reports');
+        $table->addColumn('hidden', 'boolean', array('default' => false))
+              ->update();
+    }
+}

--- a/phinx.yml
+++ b/phinx.yml
@@ -1,0 +1,15 @@
+paths:
+    migrations: %%PHINX_CONFIG_DIR%%/db/migrations
+    seeds: %%PHINX_CONFIG_DIR%%/db/seeds
+
+environments:
+    default_migration_table: phinxlog
+    default_database: production
+    production:
+        adapter: mysql
+        host: %%PHINX_DBHOST%%
+        name: %%PHINX_DBNAME%%
+        user: %%PHINX_DBUSER%%
+        pass: %%PHINX_DBPASS%%
+        port: %%PHINX_DBPORT%%
+        charset: utf8

--- a/runMigration.sh
+++ b/runMigration.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+envFile=.env
+
+# check preconditions
+if [ ! -f .env ]; then
+    echo "Your environment is not set up correctly! Move the .env.example to .env, and edit your database (DB_*)" \
+            "credentials."
+fi
+
+
+# set up environment variables from .env-file
+while read line   # iterate over lines
+do
+    if [ ! -z ${line}  ]; then
+        declare "${line}"
+    fi
+done <<< "$(cat ${envFile})" # this makes sure that the loop will not be executed in a subshell
+
+export PHINX_DBHOST=${DB_HOST}
+export PHINX_DBNAME=${DB_NAME}
+export PHINX_DBUSER=${DB_USER}
+export PHINX_DBPASS=${DB_PASSWORD}
+export PHINX_DBPORT=${DB_PORT}
+export PHINX_CHARSET=${DB_CHARSET}
+
+vendor/bin/phinx migrate -e production

--- a/schema.sql
+++ b/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE `reports` (
   `exception` VARCHAR(255) NOT NULL,
   `created_at` TIMESTAMP DEFAULT 0,
   `updated_at` TIMESTAMP DEFAULT 0 ON UPDATE CURRENT_TIMESTAMP,
+  `hidden` TINYINT(1) NOT NULL DEFAULT 0,
   FOREIGN KEY (`application_id`) REFERENCES `applications`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT,
   FOREIGN KEY (`package_name`) REFERENCES `applications`(`package_name`) ON DELETE CASCADE ON UPDATE RESTRICT
 ) CHARSET utf8 ENGINE InnoDB;


### PR DESCRIPTION
We get lots of reports but we do not want to delete them directly after we finished it. So for a better overview it is necessary to hide them and display them only when needed.

For this feature an adjustment of the database schema was necessary (to flag the reports as hidden). To make an migration easily I added the phinx tool (see: https://phinx.org/) in my first commit (fc8e429).

In the second commit I added the hide-reports feature.