### PR TITLE
[gh-pages] Make the screenshots clickable, display bigger image when clicked.

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,11 +92,22 @@ php acraviz security:rekey</pre></div>
 <h2>
 <a id="screenshots" class="anchor" href="#screenshots" aria-hidden="true"><span class="octicon octicon-link"></span></a>Screenshots</h2>
 
-<p><img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/0.png" alt="Screenshot #0" title="Screenshot #0">
-<img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/1.png" alt="Screenshot #1" title="Screenshot #1">
-<img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/2.png" alt="Screenshot #2" title="Screenshot #2">
-<img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/3.png" alt="Screenshot #3" title="Screenshot #3">
-<img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/4.png" alt="Screenshot #4" title="Screenshot #4"></p>
+<p>
+<a href="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/0.png">
+    <img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/0.png" alt="Screenshot #0" title="Screenshot #0">
+</a>
+<a href="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/1.png">
+    <img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/1.png" alt="Screenshot #1" title="Screenshot #1">
+</a>
+<a href="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/2.png">
+    <img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/2.png" alt="Screenshot #2" title="Screenshot #2">
+</a>
+<a href="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/3.png">
+    <img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/3.png" alt="Screenshot #3" title="Screenshot #3">
+</a>
+<a href="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/4.png">
+    <img src="https://raw.githubusercontent.com/vaibhavpandeyvpz/acraviz/master/assets/screenshots/4.png" alt="Screenshot #4" title="Screenshot #4"></p>
+</a>
 
 <h2>
 <a id="license" class="anchor" href="#license" aria-hidden="true"><span class="octicon octicon-link"></span></a>License</h2>


### PR DESCRIPTION
The images as they are were a little small. I had to right-click and
then "View Image" to see the screenshot in detail. This adds anchor tags
to the screenshots so that they can be viewed more easily while
browsing.