### PR TITLE
Display hide/show-controls only in reports-namespace - Fixes #13

### DIFF
--- a/assets/twig/partials/actions.twig
+++ b/assets/twig/partials/actions.twig
@@ -1,7 +1,9 @@
 <div class="btn-toolbar pull-right">
+    {% if ns == 'report' %}
     <div class="btn-group btn-group-xs show-hidden-reports-link">
         <a href="" id="show-hidden-reports" data-action="show-hidden-reports" data-value="show">Show hidden reports</a>
     </div>
+    {% endif %}
     <div class="btn-group btn-group-xs">
         <button class="btn btn-default" data-action="refresh">
             <i class="fa fa-fw fa-refresh"></i>
@@ -18,6 +20,7 @@
             <span class="hidden-xs">{{ 'buttons.deselect_all'|trans }}</span>
         </button>
     </div>
+    {% if ns == 'report' %}
     <div class="btn-group btn-group-xs">
         <button class="btn btn-warning" data-action="hide:{{ ns }}" data-url="{{ url(routes.hide) }}">
             <i class="fa fa-eye-slash"></i>
@@ -30,6 +33,7 @@
             <span class="hidden-xs">{{ 'buttons.show'|trans }}</span>
         </button>
     </div>
+    {%  endif %}
     <div class="btn-group btn-group-xs">
         <button class="btn btn-danger" data-action="delete:{{ ns }}" data-url="{{ url(routes.delete) }}">
             <i class="fa fa-fw fa-trash-o"></i>

--- a/makeReleaseBundle.sh
+++ b/makeReleaseBundle.sh
@@ -10,6 +10,6 @@ version=$1
 
 composer run-script build
 
-zip -r release-${version}.zip . -x .\* -x bower_components/\* -x node_modules/\* -x .env\* -x composer.\* \
+zip --symlinks -r release-${version}.zip . -x .\* -x bower_components/\* -x node_modules/\* -x .env\* -x composer.\* \
                                 -x bower.json -x .gitignore -x gulpfile.js -x makeReleaseBundle.sh -x package.json \
                                 -x release-\*.zip

--- a/runMigration.sh
+++ b/runMigration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 envFile=.env
 


### PR DESCRIPTION
I did not mentioned, that the actions.twig template was also used inside the applications-view. Sorry for that mistake!

Plus minor changes in runMigration and makeReleaseBundle scripts.